### PR TITLE
optimize objects redundancy

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,2 +1,2 @@
 Main-Class: umicollapse.main.Main
-Class-Path: lib/htsjdk-2.19.0.jar lib/snappy-java-1.1.7.3.jar
+Class-Path: lib/htsjdk-2.19.0.jar lib/snappy-java-1.1.7.3.jar lib/fastutil-5.0.9.jar


### PR DESCRIPTION
Hello, we run UMICollapse with our tool and detected the object-level redundancy issues. In NgramBKTree.java, the object in (of type Interval) is repeatedly created, which incurs significant overhead. In fact, it could be replaced with a long. The optimized code is in this pull request.